### PR TITLE
fix: create personal private gist for the badge

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,8 +28,8 @@ jobs:
         uses: schneegans/dynamic-badges-action@v1.6.0
         with:
           auth: ${{ secrets.WORKFLOW_TOKEN }}
-          gistID: 5e90d640f8c212ab7bbac38f72323f80
-          filename: pytest-coverage-comment__main.json
+          gistID: a85f2da56cf61e1703b531b7ca4df7bc
+          filename: badge.svg
           label: Coverage Report
           message: ${{ steps.coverageComment.outputs.coverage }}
           color: ${{ steps.coverageComment.outputs.color }}


### PR DESCRIPTION
The badge should be personal-owned. Create it according to the [example](fix-badge-gist).